### PR TITLE
Switch from doctest to Catch2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -135,7 +135,7 @@ IncludeCategories:
     Priority: 300
   - Regex: '^<tl.*'
     Priority: 300
-  - Regex: '^<doctest.*'
+  - Regex: '^<catch2.*'
     Priority: 1000
   - Regex: '^<nanobench.*'
     Priority: 1000

--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install ninja
 
       - name: Install project dependencies
-        run: sudo apt-get install -y doctest-dev libexpected-dev libfmt-dev libhwy-dev libpng-dev zlib1g-dev
+        run: sudo apt-get install -y catch2 libexpected-dev libfmt-dev libhwy-dev libpng-dev zlib1g-dev
 
       - name: Configure project
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ include(cmake/clang_tidy.cmake)
 # Project dependencies.
 include(cmake/dependencies/zlib.cmake)
 # ---
-include(cmake/dependencies/doctest.cmake)
+include(cmake/dependencies/catch2.cmake)
 include(cmake/dependencies/fmt.cmake)
 include(cmake/dependencies/libcpuid.cmake)
 include(cmake/dependencies/libpng.cmake)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ With `IMOGRIFY_BUILD_CPU_INFORMATION`:
 
 With `IMOGRIFY_BUILD_UNIT_TESTS`:
 
-* **[doctest](https://github.com/doctest/doctest)**: Fast C++ testing framework.
+* **[Catch2](https://github.com/catchorg/Catch2)**: A modern, C++-native, test framework for unit-tests.
 
 With `IMOGRIFY_BUILD_MICROBENCHMARKS`:
 
@@ -63,11 +63,11 @@ With `IMOGRIFY_BUILD_MICROBENCHMARKS`:
 
 ### vcpkg support
 
-Dependencies can optionally be retrieved and built using [vcpkg](https://github.com/microsoft/vcpkg). This is disabled by default, but it is enabled by default in the provided CMake presets. vcpkg support in imogrify uses custom triplets and ports found in the `cmake/custom_vcpkg` subfolder.
+Dependencies can optionally be retrieved and built using [vcpkg](https://github.com/microsoft/vcpkg). This is disabled by default, but it is enabled by the CMake presets provided by imogrify. vcpkg support in imogrify uses custom triplets and ports found in the `cmake/custom_vcpkg` subfolder.
 
 Using vcpkg enables extra CMake options:
 
-* `IMOGRIFY_VCPKG_USE_ZLIB_NG`: Replaces [zlib](https://www.zlib.net) with **[zlib-ng](https://github.com/zlib-ng/zlib-ng)**. zlib-ng is a zlib data compression library for the next generation systems. [libpng](http://www.libpng.org)** and [libspng](https://libspng.org) will use zlib-ng instead of zlib. On by default.
+* `IMOGRIFY_VCPKG_USE_ZLIB_NG`: Replaces [zlib](https://www.zlib.net) with **[zlib-ng](https://github.com/zlib-ng/zlib-ng)**. zlib-ng is a zlib data compression library for the next generation systems. [libpng](http://www.libpng.org) and [libspng](https://libspng.org) will use zlib-ng instead of zlib. On by default.
 
 ### CMake presets
 

--- a/cmake/dependencies/catch2.cmake
+++ b/cmake/dependencies/catch2.cmake
@@ -5,13 +5,13 @@
 include_guard(GLOBAL)
 
 if (IMOGRIFY_BUILD_UNIT_TESTS)
-	find_package(doctest REQUIRED)
+	find_package(Catch2 CONFIG REQUIRED)
 
 	add_dependency_metadata(
-		NAME doctest
-		VERSION ${doctest_VERSION}
-		DESCRIPTION "Fast C++ testing framework."
-		LICENSE_SPDX "MIT"
+		NAME "Catch2"
+		VERSION ${Catch2_VERSION}
+		DESCRIPTION "A modern, C++-native, test framework for unit-tests."
+		LICENSE_SPDX "BSL-1.0"
 		USAGE "test"
 	)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_compile_definitions(imogrify_unit_tests PRIVATE ${IMOGRIFY_CXX_COMPILE_DE
 target_compile_options(imogrify_unit_tests PRIVATE ${IMOGRIFY_CXX_COMPILE_OPTIONS})
 
 target_link_libraries(imogrify_unit_tests PRIVATE
-	doctest::doctest
+	Catch2::Catch2
 	fmt::fmt
 	PNG::PNG
 	ZLIB::ZLIB

--- a/tests/core/aligned_allocation_test.cpp
+++ b/tests/core/aligned_allocation_test.cpp
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 namespace
 {

--- a/tests/core/aligned_span_test.cpp
+++ b/tests/core/aligned_span_test.cpp
@@ -10,13 +10,13 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using imfy::aligned_span;
 
 TEST_CASE("Type traits checks.")
 {
-	static_assert(sizeof(aligned_span<unsigned int>) == (sizeof(std::size_t) + sizeof(void*)));
+	static_assert(sizeof(aligned_span<unsigned int>) == sizeof(std::size_t) + sizeof(void*));
 }
 
 TEST_CASE("Constructor checks.")

--- a/tests/core/build_test.cpp
+++ b/tests/core/build_test.cpp
@@ -9,7 +9,7 @@
 #include <array>
 #include <string_view>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace std::string_view_literals;
 

--- a/tests/core/concepts_test.cpp
+++ b/tests/core/concepts_test.cpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <memory>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 namespace
 {

--- a/tests/core/memory_block_test.cpp
+++ b/tests/core/memory_block_test.cpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using imfy::memory_block;
 

--- a/tests/image/image_size_test.cpp
+++ b/tests/image/image_size_test.cpp
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using imfy::image::image_size;
 

--- a/tests/image/png_format_test.cpp
+++ b/tests/image/png_format_test.cpp
@@ -11,7 +11,7 @@
 
 #include <zlib.h>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace imfy::png;
 using namespace imfy::image;

--- a/tests/image/raw_image_test.cpp
+++ b/tests/image/raw_image_test.cpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace imfy::image;
 

--- a/tests/preprocessor_definitions_test.cpp
+++ b/tests/preprocessor_definitions_test.cpp
@@ -3,7 +3,7 @@
  * distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("Operative system preprocessor defines.")
 {

--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -3,5 +3,9 @@
  * distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>
+#include <catch2/catch_session.hpp>
+
+int main(const int argc, char** argv)
+{
+	return Catch::Session().run(argc, argv);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,7 @@
 		"imogrify-tests": {
 			"description": "Build unit tests",
 			"dependencies": [
-				"doctest"
+				"catch2"
 			]
 		},
 		"imogrify-use-zlib": {


### PR DESCRIPTION
doctest lacks support for CMake 4.